### PR TITLE
secure approve() against race conditions

### DIFF
--- a/SharderToken.sol
+++ b/SharderToken.sol
@@ -250,7 +250,7 @@ contract SharderToken {
         // wait until the transaction is mined. Only afterwards set the new amount.
         // Otherwise you may be prone to a race condition attack.
         // See: https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
-        require(_approveTokensWithDecimal != 0 || allowed[msg.sender][_spender] == 0);
+        require(_approveTokensWithDecimal != 0 || allowance[msg.sender][_spender] == 0);
                 
         allowance[msg.sender][_spender] = _approveTokensWithDecimal;
         Approval(msg.sender, _spender, _approveTokensWithDecimal);

--- a/SharderToken.sol
+++ b/SharderToken.sol
@@ -245,6 +245,13 @@ contract SharderToken {
      * @param _approveTokensWithDecimal the max amount they can spend
      */
     function approve(address _spender, uint256 _approveTokensWithDecimal) public isNotFrozen isNotPaused returns (bool success) {
+        
+        // WARNING! When changing the approval amount, first set it back to zero AND
+        // wait until the transaction is mined. Only afterwards set the new amount.
+        // Otherwise you may be prone to a race condition attack.
+        // See: https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+        require(_approveTokensWithDecimal != 0 || allowed[msg.sender][_spender] == 0);
+                
         allowance[msg.sender][_spender] = _approveTokensWithDecimal;
         Approval(msg.sender, _spender, _approveTokensWithDecimal);
         return true;


### PR DESCRIPTION
See for race condition and the suggested fix:

- https://github.com/nimiq-network/nimiq-exchange-token/blob/3f0f9599bfe66a1371a57dab59fe080f0f56ab14/contracts/StandardToken.sol#L63
- https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
- https://docs.google.com/document/d/1YLPtQxZu1UAvO9cZ1O2RPXBbT0mooh4DYKjA_jp-RLM
- https://github.com/ethereum/EIPs/issues/738